### PR TITLE
integration tests

### DIFF
--- a/pkg/cmd/server/command.go
+++ b/pkg/cmd/server/command.go
@@ -57,7 +57,7 @@ func NewCommandStartServer(name string) (*cobra.Command, *Config) {
 
 			cfg.Complete(args)
 
-			if err := start(*cfg, args); err != nil {
+			if err := cfg.Start(args); err != nil {
 				glog.Fatal(err)
 			}
 		},

--- a/pkg/cmd/server/start.go
+++ b/pkg/cmd/server/start.go
@@ -106,7 +106,7 @@ func (cfg Config) startMaster() error {
 }
 
 // run launches the appropriate startup modes or returns an error.
-func start(cfg Config, args []string) error {
+func (cfg Config) Start(args []string) error {
 	if cfg.WriteConfigOnly {
 		return nil
 	}

--- a/test/integration/test_server.go
+++ b/test/integration/test_server.go
@@ -1,0 +1,95 @@
+// +build integration,!no-etcd
+
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
+	osclient "github.com/openshift/origin/pkg/client"
+	start "github.com/openshift/origin/pkg/cmd/server"
+)
+
+func init() {
+	requireEtcd()
+}
+
+func StartTestServer(args ...string) (*osclient.Client, error) {
+	deleteAllEtcdKeys()
+
+	startConfig := start.NewDefaultConfig()
+
+	basedir := path.Join(os.TempDir(), "openshift-integration-tests")
+
+	startConfig.VolumeDir = path.Join(basedir, "volume")
+	startConfig.EtcdDir = path.Join(basedir, "etcd")
+	startConfig.CertDir = path.Join(basedir, "cert")
+
+	masterAddr := httptest.NewUnstartedServer(nil).Listener.Addr().String()
+	fmt.Printf("masterAddr: %#v\n", masterAddr)
+
+	startConfig.MasterAddr.Set(masterAddr)
+	startConfig.BindAddr.Set(masterAddr)
+	startConfig.EtcdAddr.Set(getEtcdURL())
+
+	startConfig.Complete(args)
+
+	go func() {
+		err := startConfig.Start(args)
+		if err != nil {
+			fmt.Printf("ERROR STARTING SERVER! %v", err)
+		}
+	}()
+
+	// if we request an OpenshiftClient before Start() has minted them, we can end up messing up the
+	// increasing count of signed certs.  So instead we wait until we get back something other than
+	// connection refused and then check to see if we can make a resource query
+	// TODO clean this up actually use a proper cert since we know the location
+	clientCertCreated := false
+	stopChannel := make(chan struct{})
+	util.Until(
+		func() {
+			if !clientCertCreated {
+				url := path.Join(masterAddr, "osapi")
+				url = "https://" + url
+
+				_, err := http.Get(url)
+				if (err != nil) && !strings.Contains(err.Error(), "connection refused") {
+					clientCertCreated = true
+				}
+
+			} else {
+				client, _, err := startConfig.GetOpenshiftClient()
+				if err != nil {
+					return
+				}
+				if _, err := client.Policies("master").List(labels.Everything(), labels.Everything()); err == nil {
+					close(stopChannel)
+				}
+			}
+		}, 100*time.Millisecond, stopChannel)
+
+	client, _, err := startConfig.GetOpenshiftClient()
+	if err != nil {
+		return nil, err
+	}
+
+	return client, nil
+}
+func StartTestMaster() (*osclient.Client, error) {
+	return StartTestServer("master")
+}
+func StartTestNode() (*osclient.Client, error) {
+	return StartTestServer("node")
+}
+func StartTestAllInOne() (*osclient.Client, error) {
+	return StartTestServer()
+}

--- a/test/integration/test_server_test.go
+++ b/test/integration/test_server_test.go
@@ -1,0 +1,38 @@
+// +build integration,!no-etcd
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+)
+
+func TestStartTestAllInOne(t *testing.T) {
+	client, err := StartTestAllInOne()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	policies, err := client.Policies("master").List(labels.Everything(), labels.Everything())
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(policies.Items) == 0 {
+		t.Errorf("expected policies, but didn't get any")
+	}
+}
+func TestStartTestMaster(t *testing.T) {
+	client, err := StartTestMaster()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	policies, err := client.Policies("master").List(labels.Everything(), labels.Everything())
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(policies.Items) == 0 {
+		t.Errorf("expected policies, but didn't get any")
+	}
+}

--- a/test/integration/utils.go
+++ b/test/integration/utils.go
@@ -22,14 +22,18 @@ const (
 )
 
 func newEtcdClient() *etcd.Client {
-	etcdServers := []string{"http://127.0.0.1:4001"}
-
-	etcdFromEnv := os.Getenv("ETCD_SERVER")
-	if len(etcdFromEnv) > 0 {
-		etcdServers = []string{etcdFromEnv}
-	}
+	etcdServers := []string{getEtcdURL()}
 
 	return etcd.NewClient(etcdServers)
+}
+
+func getEtcdURL() string {
+	etcdFromEnv := os.Getenv("ETCD_SERVER")
+	if len(etcdFromEnv) > 0 {
+		return etcdFromEnv
+	}
+
+	return "http://127.0.0.1:4001"
 }
 
 func init() {


### PR DESCRIPTION
Adds an integration test method to start masters and all in ones.  Nodes seem to require a fixed port (ick).