### PR TITLE
final tweaks for service accounts

### DIFF
--- a/test/integration/buildcontroller_test.go
+++ b/test/integration/buildcontroller_test.go
@@ -27,11 +27,11 @@ var (
 
 	// ConcurrentBuildControllersTestWait is the time that TestConcurrentBuildControllers waits
 	// for any other changes to happen when testing whether only a single build got processed
-	ConcurrentBuildControllersTestWait = 5 * time.Second
+	ConcurrentBuildControllersTestWait = 15 * time.Second
 
 	// ConcurrentBuildPodControllersTestWait is the time that TestConcurrentBuildPodControllers waits
 	// after a state transition to make sure other state transitions don't occur unexpectedly
-	ConcurrentBuildPodControllersTestWait = 10 * time.Second
+	ConcurrentBuildPodControllersTestWait = 15 * time.Second
 
 	// BuildControllersWatchTimeout is used by all tests to wait for watch events. In case where only
 	// a single watch event is expected, the test will fail after the timeout.

--- a/test/integration/service_account_test.go
+++ b/test/integration/service_account_test.go
@@ -181,9 +181,9 @@ func TestServiceAccountAuthorization(t *testing.T) {
 
 func writeClientConfigToKubeConfig(config kclient.Config, path string) error {
 	kubeConfig := &clientcmdapi.Config{
-		Clusters:       map[string]clientcmdapi.Cluster{"myserver": clientcmdapi.Cluster{Server: config.Host, CertificateAuthority: config.CAFile, CertificateAuthorityData: config.CAData}},
-		AuthInfos:      map[string]clientcmdapi.AuthInfo{"myuser": clientcmdapi.AuthInfo{Token: config.BearerToken}},
-		Contexts:       map[string]clientcmdapi.Context{"mycontext": clientcmdapi.Context{Cluster: "myserver", AuthInfo: "myuser"}},
+		Clusters:       map[string]clientcmdapi.Cluster{"myserver": {Server: config.Host, CertificateAuthority: config.CAFile, CertificateAuthorityData: config.CAData}},
+		AuthInfos:      map[string]clientcmdapi.AuthInfo{"myuser": {Token: config.BearerToken}},
+		Contexts:       map[string]clientcmdapi.Context{"mycontext": {Cluster: "myserver", AuthInfo: "myuser"}},
 		CurrentContext: "mycontext",
 	}
 	if err := os.MkdirAll(filepath.Dir(path), os.FileMode(0755)); err != nil {


### PR DESCRIPTION
Creating a default service account (the actual create call) can take a few seconds.  (I've seen up to 6).  That's longer than the test wait time.  I suspect this is related to the rate limitter.  I've bumped the time up and fixed gofmt.

@smarterclayton if you're ok with this, I'll make a separate pull including @liggitt's changes to get this in today.